### PR TITLE
chore: update submodules when they change

### DIFF
--- a/.github/workflows/self_update.yaml
+++ b/.github/workflows/self_update.yaml
@@ -39,6 +39,13 @@ jobs:
             echo "No changes in repository."
             echo "changed=0" >> $GITHUB_OUTPUT
           fi
+      - name: ✍️ Commit Changes
+        if: steps.changes.outputs.changed == 1
+        run: |
+          git config user.name "action@github.com"
+          git config user.email "GitHub Action"
+          git commit -a -m "chore(version): update submodules"
+          git push
 
   release:
     uses: './.github/workflows/release.yaml'


### PR DESCRIPTION
Added a step to the self_update workflow that commits updates to submodules back into the main branch, so new published versions will have the latest GodotPackage.